### PR TITLE
fix(bug): test.result can be falsy #167

### DIFF
--- a/src/app/error/missing-result.error.ts
+++ b/src/app/error/missing-result.error.ts
@@ -1,0 +1,7 @@
+import { type ErrorWithDiff, type Test } from 'vitest'
+
+export default class MissingResultError extends Error implements ErrorWithDiff {
+  constructor(test: Test) {
+    super(`Test: "${test.name}" from - "${test.file?.filepath ?? 'unknown'}" missing a result after file test process finished`)
+  }
+}

--- a/src/app/messages/test-message.ts
+++ b/src/app/messages/test-message.ts
@@ -12,7 +12,7 @@ export class TestMessage extends Message {
     return this.generateTeamcityMessage(type, this.id, { ...parameters, name: this.name })
   }
 
-  fail(error: ErrorWithDiff | undefined): string {
+  fail = (error: ErrorWithDiff | undefined): string => {
     return this.generate('testFailed', {
       message: escape(error?.message ?? ''),
       details: escape(error?.stackStr ?? ''),
@@ -21,27 +21,27 @@ export class TestMessage extends Message {
     })
   }
 
-  started(): string {
+  started = (): string => {
     return this.generate('testStarted')
   }
 
-  finished(duration: number): string {
+  finished = (duration: number): string => {
     return this.generate('testFinished', { duration })
   }
 
-  ignored(): string {
+  ignored = (): string => {
     return this.generate('testIgnored')
   }
 
-  stdOut(out: string): string {
+  stdOut = (out: string): string => {
     return this.generate('testStdOut', { out })
   }
 
-  stdErr(out: string): string {
+  stdErr = (out: string): string => {
     return this.generate('testStdErr', { out })
   }
 
-  log(type: 'stdout' | 'stderr', out: string): string {
+  log = (type: 'stdout' | 'stderr', out: string): string => {
     return type === 'stdout' ? this.stdOut(out) : this.stdErr(out)
   }
 }

--- a/src/app/printer.ts
+++ b/src/app/printer.ts
@@ -1,17 +1,17 @@
-import { type File, type Suite, type Task, type Test, type UserConsoleLog, type TaskResultPack } from 'vitest'
+import { type File, type Suite, type Task, type TaskResultPack, type Test, type UserConsoleLog, type Vitest, type ErrorWithDiff } from 'vitest'
 import { SuitMessage } from './messages/suite-message'
 import { escape } from './escape'
 import { TestMessage } from './messages/test-message'
-import { type VitestLogger } from './reporter'
+import MissingResultError from './error/missing-result.error'
 
 type PotentialMessage = string | (() => string | string[])
 type PotentialMessages = PotentialMessage[]
 
 export class Printer {
-  private readonly fileMap = new Map<string, PotentialMessages>()
+  private readonly fileMessageMap = new Map<string, PotentialMessages>()
   private readonly testConsoleMap = new Map<string, UserConsoleLog[]>()
 
-  constructor(private readonly logger: VitestLogger) {
+  constructor(private readonly logger: Vitest['logger']) {
   }
 
   public addFile = (file: File): void => {
@@ -21,7 +21,7 @@ export class Printer {
       ...file.tasks.flatMap(this.handleTask),
       suitMessage.finished()
     ]
-    this.fileMap.set(file.id, messages)
+    this.fileMessageMap.set(file.id, messages)
   }
 
   public addTestConsoleLog(id: string, log: UserConsoleLog): void {
@@ -34,11 +34,12 @@ export class Printer {
   }
 
   public handeUpdate = ([id, result]: TaskResultPack): void => {
-    const messages = this.fileMap.get(id)
+    const messages = this.fileMessageMap.get(id)
     if ((messages != null) && (result != null) && result.state !== 'run') {
       messages
         .flatMap((message: PotentialMessage) => typeof message === 'string' ? message : message())
         .forEach(message => { this.logger.console.info(message) })
+      this.fileMessageMap.delete(id)
     }
   }
 
@@ -68,17 +69,24 @@ export class Printer {
       return testMessage.ignored()
     }
     return () => {
-      /* eslint-disable @typescript-eslint/no-non-null-assertion */
-      const fail = test.result!.state === 'fail'
+      const fail = (test.result == null) || test.result.state === 'fail'
+
       const logs = this.testConsoleMap.get(test.id) ?? []
       const logsMessages = logs.map(log => testMessage.log(log.type, log.content))
+      const filedMessages = fail ? this.getTestErrors(test).map(testMessage.fail) : []
+
       return [
         testMessage.started(),
         ...logsMessages,
-        fail ? testMessage.fail(test.result!.error) : '',
-        testMessage.finished(test.result!.duration ?? 0)
+        ...filedMessages,
+        testMessage.finished(test.result?.duration ?? 0)
       ].filter(Boolean)
-      /* eslint-enable @typescript-eslint/no-non-null-assertion */
     }
   }
+
+  private readonly getTestErrors = (test: Test): ErrorWithDiff[] =>
+    test.result?.errors ??
+      test.suite.result?.errors ??
+      test.file?.result?.errors ??
+      [new MissingResultError(test)]
 }

--- a/src/app/reporter.ts
+++ b/src/app/reporter.ts
@@ -1,12 +1,8 @@
 import { type Awaitable, type File, type Reporter, type TaskResultPack, type UserConsoleLog, type Vitest } from 'vitest'
 import { Printer } from './printer'
 
-export interface VitestLogger {
-  console: Console
-}
-
 class TeamCityReporter implements Reporter {
-  private logger!: VitestLogger
+  private logger!: Vitest['logger']
   private printer!: Printer
 
   onInit(ctx: Vitest): void {

--- a/src/test/miss-test-result/miss-test-result-with-problem.expect.ts
+++ b/src/test/miss-test-result/miss-test-result-with-problem.expect.ts
@@ -1,0 +1,12 @@
+export default [
+  ['testSuiteStarted', 'src/test/miss-test-result/miss-test-result-with-problem.spec.ts'],
+  ['testSuiteStarted', 'With delayed hook'],
+  ['testStarted', 'first test delays the execution result'],
+  ['testFailed', 'first test delays the execution result'],
+  ['testFinished', 'first test delays the execution result'],
+  ['testStarted', 'second test delays the execution result'],
+  ['testFailed', 'second test delays the execution result'],
+  ['testFinished', 'second test delays the execution result'],
+  ['testSuiteFinished', 'With delayed hook'],
+  ['testSuiteFinished', 'src/test/miss-test-result/miss-test-result-with-problem.spec.ts']
+]

--- a/src/test/miss-test-result/miss-test-result-with-problem.spec.ts
+++ b/src/test/miss-test-result/miss-test-result-with-problem.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, beforeAll, expect } from 'vitest'
+
+describe('With delayed hook', () => {
+  beforeAll(async() => {
+    return await new Promise((resolve) => setTimeout(resolve, 10000))
+  }, 100)
+
+  it('first test delays the execution result', async() => {
+    expect('true').toEqual('true')
+  })
+
+  it('second test delays the execution result', async() => {
+    expect('false').toEqual('true')
+  })
+})

--- a/src/test/miss-test-result/miss-test-result-without-problem.expect.ts
+++ b/src/test/miss-test-result/miss-test-result-without-problem.expect.ts
@@ -1,0 +1,11 @@
+export default [
+  ['testSuiteStarted', 'src/test/miss-test-result/miss-test-result-without-problem.spec.ts'],
+  ['testSuiteStarted', 'Without delayed hook'],
+  ['testStarted', 'first test'],
+  ['testFinished', 'first test'],
+  ['testStarted', 'second test'],
+  ['testFailed', 'second test'],
+  ['testFinished', 'second test'],
+  ['testSuiteFinished', 'Without delayed hook'],
+  ['testSuiteFinished', 'src/test/miss-test-result/miss-test-result-without-problem.spec.ts'],
+]

--- a/src/test/miss-test-result/miss-test-result-without-problem.spec.ts
+++ b/src/test/miss-test-result/miss-test-result-without-problem.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+
+describe('Without delayed hook', () => {
+  it('first test', async() => {
+    expect('true').toEqual('true')
+  })
+
+  it('second test', async() => {
+    expect('false').toEqual('true')
+  })
+})

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,0 +1,32 @@
+import { expect } from 'vitest'
+
+export const generateExpectTest = (info: string[], expectMap: Record<string, string[][]>): void => {
+  const gropedMessage = info.reduce((acc: { [key in string]: string[] }, message: string) => {
+    const flowId = /flowId='(.+?)'/.exec(message)?.[1] ?? ''
+    if (acc[flowId] == null) {
+      acc[flowId] = []
+    }
+    acc[flowId].push(message)
+    return acc
+  }, {})
+
+  expect(Object.keys(gropedMessage)).lengthOf(Object.keys(expectMap).length)
+
+  Object.values(gropedMessage).forEach((messages: string[]) => {
+    const fileName = /name='(.+?)'/.exec(messages[0])?.[1] ?? ''
+
+    const expectedResult = expectMap[fileName]
+
+    expect(expectedResult).not.toBeUndefined()
+
+    compareResultWithExpect(expectedResult, messages)
+  })
+}
+
+export const compareResultWithExpect = (expectedResult: string[][], result: string[]): void => {
+  expectedResult.forEach(([type, name], index) => {
+    const message = result[index]
+    expect(message).toContain(`##teamcity[${type} `)
+    expect(message).toContain(`name='${name}'`)
+  })
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig, configDefaults } from 'vitest/config'
 export default defineConfig({
   test: {
     ...configDefaults,
-    clearMocks: true
+    clearMocks: true,
   },
 })


### PR DESCRIPTION
Fix for #167

work done:
- added checking is file processed and if not then postponed to end test run
- if the test does have not a result at the end whole test run process then is marked as failed