### PR TITLE
Escape `testFailed` service message parameters only once

### DIFF
--- a/src/app/messages/test-message.ts
+++ b/src/app/messages/test-message.ts
@@ -1,11 +1,10 @@
 import { type Test, type ErrorWithDiff } from 'vitest'
-import { escape } from '../escape'
 import { Message, type Parameters } from './message'
 
 export class TestMessage extends Message {
   constructor(test: Test) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    super(test.file!.id, escape(test.name))
+    super(test.file!.id, test.name)
   }
 
   protected generate(type: string, parameters: Parameters = {}): string {

--- a/src/app/messages/test-message.ts
+++ b/src/app/messages/test-message.ts
@@ -12,12 +12,12 @@ export class TestMessage extends Message {
     return this.generateTeamcityMessage(type, this.id, { ...parameters, name: this.name })
   }
 
-  fail = (error: ErrorWithDiff | undefined): string => {
+  fail = (error: ErrorWithDiff): string => {
     return this.generate('testFailed', {
-      message: escape(error?.message ?? ''),
-      details: escape(error?.stackStr ?? ''),
-      actual: escape(error?.actual as string ?? ''),
-      expected: escape(error?.expected as string ?? ''),
+      message: error.message ?? '',
+      details: error.stackStr ?? '',
+      actual: (error.actual as string) ?? '',
+      expected: (error.expected as string) ?? '',
     })
   }
 

--- a/src/test/escape.spec.ts
+++ b/src/test/escape.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, type Test } from 'vitest'
+import { escape } from '../app/escape'
+import { SuitMessage } from '../app/messages/suite-message'
+import { TestMessage } from '../app/messages/test-message'
+
+const escapeMap = {
+  '\x1B1m': '',
+  '|': '||',
+  '\n': '|n',
+  '\r': '|r',
+  '[': '|[',
+  ']': '|]',
+  '\u0085': '|x',
+  '\u2028': '|l',
+  '\u2029': '|p',
+  "'": "|'",
+}
+
+const testNumber = Math.random()
+const expectedNumber = testNumber.toString()
+
+const testString = Object.keys(escapeMap).join('')
+const expectedString = Object.values(escapeMap).join('')
+
+describe('Checking message escaping functionality', () => {
+  it('escaping of simple string or number is correct', () => {
+    const escapedString = escape(testString)
+    expect(escapedString).toStrictEqual(expectedString)
+
+    const escapedNumber = escape(testNumber)
+    expect(escapedNumber).toStrictEqual(expectedNumber)
+  })
+
+  it('suite message parameters are correctly escaped', () => {
+    const messageId = 'messageId'
+    const messageName = 'messageName'
+    const messageType = 'messageType'
+
+    const message = new SuitMessage(messageId, messageName)
+
+    const escapedParameters = message.generate(messageType, {
+      testString,
+      testNumber,
+    })
+
+    expect(escapedParameters).toStrictEqual(
+      `##teamcity[${messageType} flowId='${messageId}' testString='${expectedString}' testNumber='${expectedNumber}' name='${messageName}']`
+    )
+  })
+
+  it('test name is correctly escaped', () => {
+    const testName = testString
+    const fileId = 'fileId'
+
+    const test = new TestMessage({
+      name: testName,
+      file: {
+        id: fileId,
+      },
+      type: 'test',
+    } as unknown as Test)
+
+    const escapedMessage = test.started()
+    expect(escapedMessage).toStrictEqual(`##teamcity[testStarted flowId='${fileId}' name='${expectedString}']`)
+  })
+})


### PR DESCRIPTION
### Problem
`testFailed` service messages get all parameters escaped twice and so, for example, new lines are printed as `|n` in TeamCity build log

<img width="1346" alt="Screenshot 2024-05-30 at 00 01 47" src="https://github.com/eratio08/vitest-teamcity-reporter/assets/3458112/8c87efd5-aa8a-4905-b204-e214047ea376">

### Proposed solution
In `TestMessage.fail()` do not escape the message parameters as they are passed to the `generate()` and the to the `generateTeamcityMessage()` methods, and the latest calls `generateParameters()` mapping each parameter to `${key}='${escape(value ?? '')}'`.

<img width="611" alt="Screenshot 2024-05-30 at 00 01 34" src="https://github.com/eratio08/vitest-teamcity-reporter/assets/3458112/007838f1-f9c6-494e-af45-5c6d3f9ebb93">

