### PR TITLE
moduleId has to be escaped

### DIFF
--- a/src/app/printer.ts
+++ b/src/app/printer.ts
@@ -14,7 +14,10 @@ export class Printer {
   constructor(private readonly logger: Vitest['logger']) {}
 
   public onModuleCollected(testModule: TestModule): void {
-    const suiteMessage = new SuiteMessage(escapeSpecials(testModule.moduleId), escapeSpecials(testModule.relativeModuleId))
+    const suiteMessage = new SuiteMessage(
+      escapeSpecials(testModule.moduleId),
+      escapeSpecials(testModule.relativeModuleId),
+    )
     this.log(suiteMessage.started())
     this.reportedSuites.add(testModule.moduleId)
   }
@@ -23,7 +26,10 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
+    const suiteMessage = new SuiteMessage(
+      escapeSpecials(testSuite.module.moduleId),
+      escapeSpecials(testSuite.name),
+    )
     this.log(suiteMessage.started())
     this.reportedSuites.add(testSuite.id)
   }
@@ -84,13 +90,19 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
+    const suiteMessage = new SuiteMessage(
+      escapeSpecials(testSuite.module.moduleId),
+      escapeSpecials(testSuite.name),
+    )
     this.log(suiteMessage.finished())
     this.reportedSuites.delete(testSuite.id)
   }
 
   public onModuleEnd(testModule: TestModule): void {
-    const suiteMessage = new SuiteMessage(escapeSpecials(testModule.moduleId), escapeSpecials(testModule.moduleId))
+    const suiteMessage = new SuiteMessage(
+      escapeSpecials(testModule.moduleId),
+      escapeSpecials(testModule.moduleId),
+    )
     this.log(suiteMessage.finished())
     this.reportedSuites.delete(testModule.moduleId)
   }

--- a/src/app/printer.ts
+++ b/src/app/printer.ts
@@ -14,7 +14,7 @@ export class Printer {
   constructor(private readonly logger: Vitest['logger']) {}
 
   public onModuleCollected(testModule: TestModule): void {
-    const suiteMessage = new SuiteMessage(testModule.moduleId, escapeSpecials(testModule.relativeModuleId))
+    const suiteMessage = new SuiteMessage(escapeSpecials(testModule.moduleId), escapeSpecials(testModule.relativeModuleId))
     this.log(suiteMessage.started())
     this.reportedSuites.add(testModule.moduleId)
   }
@@ -23,7 +23,7 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(testSuite.module.moduleId, escapeSpecials(testSuite.name))
+    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
     this.log(suiteMessage.started())
     this.reportedSuites.add(testSuite.id)
   }
@@ -84,13 +84,13 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(testSuite.module.moduleId, escapeSpecials(testSuite.name))
+    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
     this.log(suiteMessage.finished())
     this.reportedSuites.delete(testSuite.id)
   }
 
   public onModuleEnd(testModule: TestModule): void {
-    const suiteMessage = new SuiteMessage(testModule.moduleId, escapeSpecials(testModule.moduleId))
+    const suiteMessage = new SuiteMessage(escapeSpecials(testModule.moduleId), escapeSpecials(testModule.moduleId))
     this.log(suiteMessage.finished())
     this.reportedSuites.delete(testModule.moduleId)
   }

--- a/src/app/printer.ts
+++ b/src/app/printer.ts
@@ -26,10 +26,7 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(
-      escapeSpecials(testSuite.module.moduleId),
-      escapeSpecials(testSuite.name),
-    )
+    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
     this.log(suiteMessage.started())
     this.reportedSuites.add(testSuite.id)
   }


### PR DESCRIPTION
there is an error when creating the SuiteMessage. Some paths in react can contain [ or ].
It has to be escaped. Otherwise the SuiteMessage with the moduleId will be incorrect and the teamcity reporter will throw errors when executing vitest