### PR TITLE
moduleId has to be escaped for SuiteMessage

### DIFF
--- a/src/app/printer.ts
+++ b/src/app/printer.ts
@@ -87,19 +87,13 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(
-      escapeSpecials(testSuite.module.moduleId),
-      escapeSpecials(testSuite.name),
-    )
+    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
     this.log(suiteMessage.finished())
     this.reportedSuites.delete(testSuite.id)
   }
 
   public onModuleEnd(testModule: TestModule): void {
-    const suiteMessage = new SuiteMessage(
-      escapeSpecials(testModule.moduleId),
-      escapeSpecials(testModule.moduleId),
-    )
+    const suiteMessage = new SuiteMessage(escapeSpecials(testModule.moduleId), escapeSpecials(testModule.moduleId))
     this.log(suiteMessage.finished())
     this.reportedSuites.delete(testModule.moduleId)
   }

--- a/src/app/printer.ts
+++ b/src/app/printer.ts
@@ -14,7 +14,10 @@ export class Printer {
   constructor(private readonly logger: Vitest['logger']) {}
 
   public onModuleCollected(testModule: TestModule): void {
-    const suiteMessage = new SuiteMessage(escapeSpecials(testModule.moduleId), escapeSpecials(testModule.relativeModuleId))
+    const suiteMessage = new SuiteMessage(
+      escapeSpecials(testModule.moduleId),
+      escapeSpecials(testModule.relativeModuleId),
+    )
     this.log(suiteMessage.started())
     this.reportedSuites.add(testModule.moduleId)
   }
@@ -23,7 +26,10 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
+    const suiteMessage = new SuiteMessage(
+      escapeSpecials(testSuite.module.moduleId),
+      escapeSpecials(testSuite.name),
+    )
     this.log(suiteMessage.started())
     this.reportedSuites.add(testSuite.id)
   }
@@ -84,13 +90,19 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
+    const suiteMessage = new SuiteMessage(
+      escapeSpecials(testSuite.module.moduleId),
+      escapeSpecials(testSuite.name),
+    )
     this.log(suiteMessage.finished())
     this.reportedSuites.delete(testSuite.id)
   }
 
   public onModuleEnd(testModule: TestModule): void {
-    const suiteMessage = new SuiteMessage(escapeSpecials(testModule.moduleId), escapeSpecials(testModule.moduleId))
+    const suiteMessage = new SuiteMessage(
+      escapeSpecials(testModule.moduleId),
+      escapeSpecials(testModule.moduleId),
+    )
     this.log(suiteMessage.finished())
     this.reportedSuites.delete(testModule.moduleId)
   }

--- a/src/app/printer.ts
+++ b/src/app/printer.ts
@@ -14,7 +14,7 @@ export class Printer {
   constructor(private readonly logger: Vitest['logger']) {}
 
   public onModuleCollected(testModule: TestModule): void {
-    const suiteMessage = new SuiteMessage(testModule.moduleId, escapeSpecials(testModule.relativeModuleId))
+    const suiteMessage = new SuiteMessage(escapeSpecials(testModule.moduleId), escapeSpecials(testModule.relativeModuleId))
     this.log(suiteMessage.started())
     this.reportedSuites.add(testModule.moduleId)
   }
@@ -23,7 +23,7 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(testSuite.module.moduleId, escapeSpecials(testSuite.name))
+    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
     this.log(suiteMessage.started())
     this.reportedSuites.add(testSuite.id)
   }
@@ -84,13 +84,13 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(testSuite.module.moduleId, escapeSpecials(testSuite.name))
+    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
     this.log(suiteMessage.finished())
     this.reportedSuites.delete(testSuite.id)
   }
 
   public onModuleEnd(testModule: TestModule): void {
-    const suiteMessage = new SuiteMessage(testModule.moduleId, escapeSpecials(testModule.moduleId))
+    const suiteMessage = new SuiteMessage(escapeSpecials(testModule.moduleId), escapeSpecials(testModule.moduleId))
     this.log(suiteMessage.finished())
     this.reportedSuites.delete(testModule.moduleId)
   }

--- a/src/app/printer.ts
+++ b/src/app/printer.ts
@@ -26,10 +26,7 @@ export class Printer {
     if (this.isSkippedOrTodo(testSuite)) {
       return
     }
-    const suiteMessage = new SuiteMessage(
-      escapeSpecials(testSuite.module.moduleId),
-      escapeSpecials(testSuite.name),
-    )
+    const suiteMessage = new SuiteMessage(escapeSpecials(testSuite.module.moduleId), escapeSpecials(testSuite.name))
     this.log(suiteMessage.started())
     this.reportedSuites.add(testSuite.id)
   }

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -10,6 +10,8 @@ import sequenceSyncExpect from './sequence-check/sync.expect'
 import workCheckExpect from './simple/work-check.expect'
 import { compareResultWithExpect, generateExpectTest } from './utils'
 
+vi.setConfig({ testTimeout: 15000 })
+
 describe('main tests', () => {
   // biome-ignore lint/suspicious/noExplicitAny: fine for the test
   let consoleStub: any

--- a/src/test/miss-test-result/miss-test-result-with-problem.expect.ts
+++ b/src/test/miss-test-result/miss-test-result-with-problem.expect.ts
@@ -2,7 +2,6 @@ export default [
   ['testSuiteStarted', 'src/test/miss-test-result/miss-test-result-with-problem.spec.ts'],
   ['testSuiteStarted', 'With delayed hook'],
   ['testStarted', 'first test delays the execution result'],
-  ['testFailed', 'first test delays the execution result'],
   ['testFinished', 'first test delays the execution result'],
   ['testStarted', 'second test delays the execution result'],
   ['testFailed', 'second test delays the execution result'],

--- a/src/test/miss-test-result/miss-test-result-with-problem.spec.ts
+++ b/src/test/miss-test-result/miss-test-result-with-problem.spec.ts
@@ -3,7 +3,7 @@ import { beforeAll, describe, expect, it } from 'vitest'
 describe('With delayed hook', () => {
   beforeAll(async () => {
     return await new Promise((resolve) => setTimeout(resolve, 10000))
-  }, 100)
+  }, 10000)
 
   it('first test delays the execution result', async () => {
     expect('true').toEqual('true')


### PR DESCRIPTION
there is an error when creating the SuiteMessage. Some paths in react can contain [ or ].
It has to be escaped. Otherwise the SuiteMessage with the moduleId will be incorrect and the teamcity reporter will throw errors when executing vitest